### PR TITLE
Fixed the volume down command to be according to Rotel specification

### DIFF
--- a/media_player.py
+++ b/media_player.py
@@ -135,7 +135,7 @@ class RotelDevice(MediaPlayerEntity):
 
     def volume_down(self) -> None:
         """Step volume down one increment."""
-        self.send_request('vol_down!')
+        self.send_request('vol_dwn!')
 
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""


### PR DESCRIPTION
The volume down is : "vol_dwn!" and not "vol_down!"

This commit fixes the volume down button in HA. 